### PR TITLE
Use default stop accelerator

### DIFF
--- a/readsdcomics.py
+++ b/readsdcomics.py
@@ -284,7 +284,6 @@ class ReadSDComics(activity.Activity):
         separator.show()
 
         stop_button = StopButton(self)
-        stop_button.props.accelerator = '<Ctrl><Shift>Q'
         toolbar_box.toolbar.insert(stop_button, -1)
         stop_button.show()
 


### PR DESCRIPTION
Stop accelerator was ctrl+shift+q, but now is ctrl+q.

The default accelerator is defined in the toolkit, so there is no
need to set it in the activity code.  It is defined by the stop button.
@quozl please review.Thanks!